### PR TITLE
added docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         container_name: jottacloud-cli
         environment:
             - JOTTA_TOKEN=YOUR_AUTH_KEY_GOES_HERE
-            - JOTTA_DEVICE=YOUR_MACHINE_NAME_GOES HERE
+            - JOTTA_DEVICE=YOUR_MACHINE_NAME_GOES_HERE
             - JOTTA_SCANINTERVAL=10m #0 for realtime, 10m, 1h etc
             - LOCALTIME=Europe/Zurich
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,13 @@ services:
     jottacloud:
         container_name: jottacloud-cli
         environment:
-            - JOTTA_TOKEN=eyJ1c2VybmFtZSI6IjVjYjBhNzEyZTMxOWE3MDEzMzhmYjVkMyIsInJlYWxtIjoiam90dGFjbG91ZCIsIndlbGxfa25vd25fbGluayI6Imh0dHBzOi8vaWQuam90dGFjbG91ZC5jb20vYXV0aC9yZWFsbXMvam90dGFjbG91ZC8ud2VsbC1rbm93bi9vcGVuaWQtY29uZmlndXJhdGlvbiIsImF1dGhfdG9rZW4iOiI0MDIyOEI4NDgxRkQyNzhBMEI2NzRGOEIyMjJENUFEQyJ9
-            - JOTTA_DEVICE=ThorPi
-            - JOTTA_SCANINTERVAL=10m
+            - JOTTA_TOKEN=YOUR_AUTH_KEY_GOES_HERE
+            - JOTTA_DEVICE=YOUR_MACHINE_NAME_GOES HERE
+            - JOTTA_SCANINTERVAL=10m #0 for realtime, 10m, 1h etc
             - LOCALTIME=Europe/Zurich
         volumes:
             - './:/data/jottad'
             - './.ignore:/data/jottad/.ignore'
             - './jottad.env:/data/jottad/jottad.env'
-            - '/home/:/backup/home'
-            - '/mnt/BlackUSB/backups/:/backup/mnt/BlackUSB/backups'
+            - '/home/:/backup/home' #add lines like this for multiple back up folders
         image: bluet/jottacloud

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         environment:
             - JOTTA_TOKEN=YOUR_AUTH_KEY_GOES_HERE
             - JOTTA_DEVICE=YOUR_MACHINE_NAME_GOES_HERE
-            - JOTTA_SCANINTERVAL=10m #0 for realtime, 10m, 1h etc
+            - JOTTA_SCANINTERVAL=10m # 0 for realtime, 10m, 1h etc
             - LOCALTIME=Europe/Zurich
         volumes:
             - './:/data/jottad'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.3'
+services:
+    jottacloud:
+        container_name: jottacloud-cli
+        environment:
+            - JOTTA_TOKEN=eyJ1c2VybmFtZSI6IjVjYjBhNzEyZTMxOWE3MDEzMzhmYjVkMyIsInJlYWxtIjoiam90dGFjbG91ZCIsIndlbGxfa25vd25fbGluayI6Imh0dHBzOi8vaWQuam90dGFjbG91ZC5jb20vYXV0aC9yZWFsbXMvam90dGFjbG91ZC8ud2VsbC1rbm93bi9vcGVuaWQtY29uZmlndXJhdGlvbiIsImF1dGhfdG9rZW4iOiI0MDIyOEI4NDgxRkQyNzhBMEI2NzRGOEIyMjJENUFEQyJ9
+            - JOTTA_DEVICE=ThorPi
+            - JOTTA_SCANINTERVAL=10m
+            - LOCALTIME=Europe/Zurich
+        volumes:
+            - './:/data/jottad'
+            - './.ignore:/data/jottad/.ignore'
+            - './jottad.env:/data/jottad/jottad.env'
+            - '/home/:/backup/home'
+            - '/mnt/BlackUSB/backups/:/backup/mnt/BlackUSB/backups'
+        image: bluet/jottacloud


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `docker-compose.yml` defining a `jottacloud` service with env vars and volume mounts for backups using `bluet/jottacloud`.
> 
> - **Docker Compose**:
>   - Adds `docker-compose.yml` with `jottacloud` service (`container_name: jottacloud-cli`).
>   - Configures environment variables: `JOTTA_TOKEN`, `JOTTA_DEVICE`, `JOTTA_SCANINTERVAL`, `LOCALTIME`.
>   - Mounts volumes for data/config (`./:/data/jottad`, `./.ignore`, `./jottad.env`) and backup source (`/home/` -> `/backup/home`).
>   - Uses image `bluet/jottacloud`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 486de2603e99ff070ee0355263d4650dd8a580bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added Docker Compose configuration for streamlined deployment and development. Includes a pre-configured service with support for environment-based customization, volume mappings for data and backup directories, automated scanning intervals, and timezone settings for quick setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->