### PR TITLE
Directories with spaces would not be added

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -128,7 +128,7 @@ done
 
 echo "Adding backups"
 
-for dir in /backup/* ; do if [ -d "${dir}" ]; then set +e && jotta-cli add /$dir && set -e; fi; done
+for dir in /backup/* ; do if [ -d "${dir}" ]; then set +e && jotta-cli add "${dir}" && set -e; fi; done
 
 # load ignore file
 if [ -f /config/ignorefile ]; then


### PR DESCRIPTION
Directories with spaces would not be added to jotta-cli. Changed /$dir to "${dir}" to have it add directories with spaces and solve the warning from issue 5 https://github.com/bluet/docker-jottacloud/issues/5

<!-- ELLIPSIS_HIDDEN -->

---

> [!IMPORTANT]
> Fixes handling of directories with spaces in `entrypoint.sh` by updating directory reference syntax for `jotta-cli`.
>
> - **Behavior**:
>   - Fixes handling of directories with spaces in `entrypoint.sh` by changing `/backup/$dir` to `/backup/"${dir}"`.
>   - Addresses warning from issue 5 in the repository.
> - **Misc**:
>   - Minor change in `entrypoint.sh` to improve compatibility with directories containing spaces.
>
> This description was created by ![Ellipsis](https://img.shields.io/badge/Ellipsis-blue?color=175173) for 1dba856799e7e9650aa0123997aa9d8c4188ade4. It will automatically update as commits are pushed.

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Addressed a directory path issue to ensure backups are processed with the correct paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->